### PR TITLE
Upgrade Mathlive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## unreleased
+
+- More soon.
+
+## 0.0.1
+
+First release!

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -2,36 +2,65 @@
 
 `clj`, `shadow-cljs`, `node` and `babashka`.
 
-## Releasing Github Pages
+## Github Pages, Docs Notebook
 
-TODO discuss the documentation notebook, how we build it, how we use Clerk etc.'
+The project's [Github Pages
+site](https://mentat-collective.github.io/mathlive.cljs) hosts an interactive
+[Clerk](https://github.com/nextjournal/clerk) notebook demonstrating the
+library's use.
 
-To generate the Github Pages site in the `public` folder, run:
+### Local Notebook Dev
+
+To start a shadow-cljs process watcher for the JS required to run the Clerk
+notebook, run
 
 ```
-bb github-pages
+bb dev-notebook
 ```
 
-This is run by the Github Action to actually publish.
+Then start a Clojure process however you like, and run `(user/start!)` to run
+the Clerk server. This command should open up `localhost:7777`.
 
-To locally generate a copy of the documentation notebook, run
+### Github Pages Static Build
+
+To test the Pages build locally:
 
 ```
 bb publish-local
 ```
 
-After the build is complete, visit http://127.0.0.1:8080/ to see the production
-build of the documentation notebook.
+This will generate the static site in `public`, start a development http server
+and open up a browser window (http://127.0.0.1:8080/) with the production build
+of the documentation notebook.
+
+### Pages Build
+
+To build and release to Github Pages:
+
+```
+bb release-gh-pages
+```
+
+This will ship the site to https://mentat-collective.github.io/mathlive.cljs/.
 
 ## Publishing to Clojars
 
-- Update the version in build.clj
-- Make a new Github Release
+The template for the project's `pom.xml` lives at
+[`template/pom.xml`](https://github.com/mentat-collective/mathlive.cljs/blob/main/template/pom.xml).
 
-Launching the release will create a new tag and trigger the following command:
+To create a new release:
+
+- Update the version in
+  [build.clj](https://github.com/mentat-collective/mathlive.cljs/blob/main/build.clj)
+- Make a new [Github
+  Release](https://github.com/mentat-collective/mathlive.cljs/releases) with tag
+  `v<the-new-version>`.
+
+Submitting the release will create the new tag and trigger the following
+command:
 
 ```
-clojure -T:build publish
+bb release
 ```
 
 The new release will appear on Clojars.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,96 @@
 # mathlive.cljs
 
-A light ClojureScript wrapper over [Mathlive][MATHLIVE].
+A [ClojureScript][CLJS] + [Reagent][REAGENT] wrapper over the [MathLive][MATHLIVE] equation editor.
 
 [![Build Status](https://github.com/mentat-collective/mathlive.cljs/actions/workflows/kondo.yml/badge.svg?branch=main)](https://github.com/mentat-collective/mathlive.cljs/actions/workflows/kondo.yml)
 [![License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/mentat-collective/mathlive.cljs/blob/main/LICENSE)
 [![cljdoc badge](https://cljdoc.org/badge/org.mentat/mathlive.cljs)](https://cljdoc.org/d/org.mentat/mathlive.cljs/CURRENT)
 [![Clojars Project](https://img.shields.io/clojars/v/org.mentat/mathlive.cljs.svg)](https://clojars.org/org.mentat/mathlive.cljs)
 
-In progress!
+## Quickstart
 
-- how to use / require the library
-- usage example
-- notebook link and source
-- how to convert from mathlive proper...
+Install `mathlive.cljs` into your Clojurescript project using the instructions
+at its Clojars page:
 
-## Mathlive Examples
+[![Clojars
+Project](https://img.shields.io/clojars/v/org.mentat/mathlive.cljs.svg)](https://clojars.org/org.mentat/mathlive.cljs)
 
-- TODO get the examples directory linked
+Require `mathlive.core` in your namespace:
+
+```clj
+(ns my-app
+   (:require [mathlive.core :as ml]
+             [reagent.core :as r]))
+```
+
+The main entrypoint to the library is the `mathlive.core/Mathfield` component.
+This component acts like a Reagent `[:textarea ,,,]` and takes similar props,
+but allows for interactive mathematical input and conversion to LaTeX.
+
+Here's an example component:
+
+```clj
+(r/with-let
+  [!tex      (r/atom "")
+   on-change #(reset! !tex (.getValue (.-target %)))]
+  [:<>
+   [ml/Mathfield
+    {:value     @!tex
+     :on-change on-change}]
+   [:pre @!tex]])
+```
+
+![2022-12-01 16 56 20](https://user-images.githubusercontent.com/69635/205183928-e0fb6227-c45c-4db7-982d-c8e8a3cb3ee8.gif)
+
+See the project's [interactive documentation
+notebook](https://github.com/mentat-collective/mathlive.cljs) for more examples.
+The [MathLive guides](https://cortexjs.io/mathlive/guides/interacting/) are
+great resources as well.
+
+## Interactive Documentation via Clerk
+
+The project's [interactive
+documentation](https://mentat-collective.github.io/mathlive.cljs) was generated
+using Nextjournal's [Clerk](https://github.com/nextjournal/clerk). If you'd like
+to edit or play with the documentation, you'll need to install
+
+- [node.js](https://nodejs.org/en/)
+- The [clojure command line tool](https://clojure.org/guides/install_clojure)
+- [Babashka](https://github.com/babashka/babashka#installation)
+
+Once this is done, run this command in one terminal window to build and serve the custom JS required by the notebook:
+
+```
+bb dev-notebook
+```
+
+In another terminal window, run
+
+```
+bb start-clerk
+```
+
+This should open a browser window to `http://localhost:7777` with the contents
+of the documentation notebook. Any edits you make to `dev/mathlive/notebook.clj`
+will be picked up and displayed in the browser on save.
+
+## Thanks and Support
+
+To support this work and my other open source projects, consider sponsoring me
+via my [GitHub Sponsors page](https://github.com/sponsors/sritchie). Thank you
+to my current sponsors!
+
+I'm grateful to [Clojurists Together](https://www.clojuriststogether.org/) for
+financial support during this library's creation. Please consider [becoming a
+member](https://www.clojuriststogether.org/developers/) to support this work and
+projects like it.
 
 ## License
 
-[MIT](LICENSE).
+Copyright © 2022 Sam Ritchie.
 
+Distributed under the [MIT License](LICENSE). See [LICENSE](LICENSE).
+
+[CLJS]: https://clojurescript.org/
 [MATHLIVE]: https://github.com/arnog/mathlive
+[REAGENT]: https://reagent-project.github.io/

--- a/bb.edn
+++ b/bb.edn
@@ -16,16 +16,12 @@
   (do (shell "npm ci")
       (shell "npm run release-clerk")
       (shell "clojure -X:dev:clerk user/github-pages!")
-      (shell "rm public/index.html")
-      (shell "mv public/dev/mathlive/notebook.html" "public/index.html")
       (run 'sha))
 
   publish-local
   (do (shell "npm install")
       (shell "npm run release-clerk")
       (shell "clojure -X:dev:clerk user/publish-local!")
-      (shell "rm public/index.html")
-      (shell "mv public/dev/mathlive/notebook.html" "public/index.html")
       (run 'sha)
       (shell "npm run serve"))
 

--- a/bb.edn
+++ b/bb.edn
@@ -12,11 +12,18 @@
   (do (shell "npm install")
       (shell "npm run watch-clerk"))
 
-  github-pages
+  start-clerk
+  (shell "clojure -X:dev:clerk user/start!")
+
+  publish-gh-pages
   (do (shell "npm ci")
       (shell "npm run release-clerk")
       (shell "clojure -X:dev:clerk user/github-pages!")
       (run 'sha))
+
+  release-gh-pages
+  (do (run 'publish-pages)
+      (shell "npm run gh-pages"))
 
   publish-local
   (do (shell "npm install")

--- a/dev/mathlive/notebook.clj
+++ b/dev/mathlive/notebook.clj
@@ -1,23 +1,49 @@
 ;; # MathLive.cljs
 ;;
-;; _Generated from [this notebook](https://github.com/mentat-collective/mathlive.cljs/blob/$GIT_SHA/dev/mathlive/notebook.clj)!_
+;; A [ClojureScript](https://clojurescript.org/) + [Reagent](https://reagent-project.github.io/) wrapper over
+;; the [MathLive](https://github.com/arnog/mathlive) equation editor.
+
+;; [![Build Status](https://github.com/mentat-collective/mathlive.cljs/actions/workflows/kondo.yml/badge.svg?branch=main)](https://github.com/mentat-collective/mathlive.cljs/actions/workflows/kondo.yml)
+;; [![License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/mentat-collective/mathlive.cljs/blob/main/LICENSE)
+;; [![cljdoc badge](https://cljdoc.org/badge/org.mentat/mathlive.cljs)](https://cljdoc.org/d/org.mentat/mathlive.cljs/CURRENT)
+;; [![Clojars Project](https://img.shields.io/clojars/v/org.mentat/mathlive.cljs.svg)](https://clojars.org/org.mentat/mathlive.cljs)
 ;;
-;; Reagent component wrapping the `math-field` web component from
-;; the [MathLive](https://github.com/arnog/mathlive) JS library. See the [Github
-;; project](https://github.com/mentat-collective/mathlive.cljs) for more
-;; details.
+;; > The interactive documentation on this page was generated from [this source
+;; > file](https://github.com/mentat-collective/mathlive.cljs/blob/$GIT_SHA/dev/mathlive/notebook.clj)
+;; > using [Clerk](https://github.com/nextjournal/clerk). Follow
+;; > the [instructions in the
+;; > README](https://github.com/mentat-collective/mathlive.cljs/tree/main#interactive-documentation-via-clerk)
+;; > to run and modify this notebook on your machine!
 ;;
-;; ## Usage
+;; See the [Github project](https://github.com/mentat-collective/mathlive.cljs)
+;; for more details.
+;;
+;; ## Quickstart
+;;
+;; Install `mathlive.cljs` into your Clojurescript project using the
+;; instructions at its Clojars page:
+
+;; [![Clojars
+;;    Project](https://img.shields.io/clojars/v/org.mentat/mathlive.cljs.svg)](https://clojars.org/org.mentat/mathlive.cljs)
+;;
+;; Or grab the most recent code using a Git dependency:
 ;;
 ;; ```clj
 ;; ;; deps
 ;; {org.mentat/mathlive.cljs {:git/sha "$GIT_SHA"}}
-;;
-;; ;; namespace
+;;```
+
+;; Require `mathlive.core` in your namespace:
+
+;; ```clj
 ;; (ns my-app
 ;;   (:require [mathlive.core :as ml]
 ;;             [reagent.core :as reagent]))
-;;```
+;; ```
+
+;; The main entrypoint to the library is the `mathlive.core/Mathfield` component.
+;; This component acts like a Reagent `[:textarea ,,,]` and takes similar props,
+;; but allows for interactive mathematical input and conversion to LaTeX.
 
 ^#:nextjournal.clerk
 {:toc true
@@ -42,8 +68,75 @@ math-field:focus-within {
   outline: -webkit-focus-ring-color auto 1px
 }"])
 
-;; ## Demo
+;; ## Basic Mathfield
 ;;
+;; The simplest way to create a Mathfield is to create a component with no
+;; properties:
+
+(cljs
+ [ml/Mathfield])
+
+;; This will render an "uncontrolled" equation editor. Play around with
+;; the [keyboard shortcuts](https://cortexjs.io/mathlive/reference/keybindings/)
+;; from the [MathLive site](https://cortexjs.io/mathlive).
+
+;; ### Uncontrolled Component
+
+;; Just like a `:textarea`, you can pre-populate a `Mathfield` instance by
+;; supplying it with a LaTeX string through the `:default-value` property:
+
+(cljs
+ [ml/Mathfield
+  {:default-value "1+\\cos(x)^2"}])
+
+;; ### Controlled Component
+;;
+;; A "controlled" `Mathfield` has its value set by `:value`, and feeds each new
+;; value out via the `:on-change` callback.
+;;
+;; Here is an example of a `Mathfield` that persists its state into a reagent
+;; atom. The contents of the atom feed into the `Mathfield` and also into an
+;; adjacent block of code.
+
+(cljs
+ (reagent/with-let
+   [!tex      (reagent/atom "1+\\cos(x)^2")
+    on-change #(reset! !tex (.getValue (.-target %)))]
+   [:<>
+    [ml/Mathfield
+     {:value     @!tex
+      :on-change on-change}]
+    [:pre @!tex]]))
+
+;; ### Mathfield <-> TextArea
+;;
+;; Here is a slightly more complicated example from the ["changing the
+;; content"](https://cortexjs.io/mathlive/guides/interacting/#changing-the-content-of-a-mathfield)
+;; MathLive demo.
+;;
+;; Try changing the `:textarea` or the `Mathfield`. Reagent will keep the two in
+;; sync.
+
+(cljs
+ (reagent/with-let
+   [!tex (reagent/atom
+          "x=\\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}")
+    on-change #(reset! !tex (.. % -target -value))]
+   [:<>
+    [:h4 "Math Field"]
+    [ml/Mathfield
+     {:value @!tex
+      :on-change on-change}]
+    [:h4 "Text Area"]
+    [:textarea
+     {:style {:width "100%" :border "0.5px solid"}
+      :value @!tex
+      :on-change on-change}]]))
+
+;; ## MathJSON
+;;
+;; TODO get the mathjson out, split out virtual keyboard mode.
+
 ;; Let's get some shared state:
 
 (cljs
@@ -59,46 +152,26 @@ math-field:focus-within {
   {:options {:virtualKeyboardMode "manual"}
    :value   (:text @state)
    :on-change
-   (fn [x]
-     (swap! state assoc
-            :text     (.getValue (.-target x))
-            :mathjson (ml/->math-json (.-target x))))}])
+   (fn [event]
+     (let [mf (.-target event)]
+       (swap! state assoc
+              :text     (.getValue mf)
+              :mathjson (ml/->math-json mf))))}])
 
 ;; On every change the `Mathfield` mirrors its value into `state`. We can render
 ;; the value stored under `:text` as TeX using Clerk:
 
 (cljs
- (v/tex (:text @state)))
+ (v/tex
+  (:text @state)))
 
 ;; We can also pull the expression out as MathJSON:
 
 (cljs
- (v/code (:mathjson @state)))
-
-;; ## Controlled Mathfield
-;;
-;; This is the demo from ["changing the
-;; content"](https://cortexjs.io/mathlive/guides/interacting/#changing-the-content-of-a-mathfield).
-
-(cljs
- (reagent/with-let
-   [text (reagent/atom
-          "x=\\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}")
-    on-change #(reset! text (.. % -target -value))]
-   [:<>
-    [:h4 "Math Field"]
-    [ml/Mathfield
-     {:value @text
-      :on-change on-change}]
-    [:h4 "Text Area"]
-    [:textarea
-     {:style {:width "100%" :border "0.5px solid"}
-      :value @text
-      :on-change on-change}]]))
+ (v/code
+  (:mathjson @state)))
 
 ;; ## Fill In the Blank
-
-
 
 (cljs
  (reagent/with-let
@@ -109,10 +182,10 @@ math-field:focus-within {
    [:<>
     [ml/Mathfield
      {:read-only true
+      :on-placeholder-change on-change
       :value
       "f(x) := [\\placeholder[x-body][x]{},
-                \\placeholder[y-body][y]{}]"
-      :on-change on-change}]
+                \\placeholder[y-body][y]{}]"}]
     [v/inspect
      (v/code @m)]]))
 
@@ -139,10 +212,9 @@ math-field:focus-within {
   {:default-value "\\scriptCapitalE=\\smallfrac{5}{7}+\\frac{5}{7}"
    :options
    (fn [opts]
-     (update opts :macros
-             merge
-             {"smallfrac"
-              "{}^{#1}\\!\\!/\\!{}_{#2}"}))}])
+     (update opts :macros assoc
+             "smallfrac"
+             "{}^{#1}\\!\\!/\\!{}_{#2}"))}])
 
 ;; ## Shortcuts
 
@@ -155,8 +227,8 @@ math-field:focus-within {
   {:options
    (fn [opts]
      (update opts :inlineShortcuts
-             merge
-             {"cake" "\\Gamma"}))}])
+             assoc
+             "cake" "\\Gamma"))}])
 
 ;; ## Utilities
 
@@ -189,3 +261,26 @@ math-field:focus-within {
      {:on-change on-change}]
     [v/inspect
      (v/code @mathjson)]]))
+
+;; ## MathLive Guides
+;;
+;; This just scratches the surface! TODO add more detail here.
+
+;; ## Thanks and Support
+
+;; To support this work and my other open source projects, consider sponsoring
+;; me via my [GitHub Sponsors page](https://github.com/sponsors/sritchie). Thank
+;; you to my current sponsors!
+
+;; I'm grateful to [Clojurists Together](https://www.clojuriststogether.org/)
+;; for financial support during this library's creation. Please
+;; consider [becoming a member](https://www.clojuriststogether.org/developers/)
+;; to support this work and projects like it.
+
+;; ## License
+
+;; Copyright © 2022 Sam Ritchie.
+
+;; Distributed under the [MIT
+;; License](https://github.com/mentat-collective/mathlive.cljs/blob/main/LICENSE).
+;; See [LICENSE](https://github.com/mentat-collective/mathlive.cljs/blob/main/LICENSE).

--- a/dev/mathlive/notebook.clj
+++ b/dev/mathlive/notebook.clj
@@ -98,6 +98,8 @@ math-field:focus-within {
 
 ;; ## Fill In the Blank
 
+
+
 (cljs
  (reagent/with-let
    [m         (reagent/atom {})
@@ -108,8 +110,8 @@ math-field:focus-within {
     [ml/Mathfield
      {:read-only true
       :value
-      "f(x) := [\\placeholder[x-body]{x},
-                \\placeholder[y-body]{y}]"
+      "f(x) := [\\placeholder[x-body][x]{},
+                \\placeholder[y-body][y]{}]"
       :on-change on-change}]
     [v/inspect
      (v/code @m)]]))

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -35,7 +35,7 @@
   ;; TODO this now defaults to a project page. Do we want to change this?
   (swap! config/!resource->url merge {"/js/viewer.js" "/mathlive.cljs/js/main.js"})
   (clerk/build!
-   {:paths ["dev/mathlive/notebook.clj"]
+   {:index "dev/mathlive/notebook.clj"
     :bundle? false
     :browse? false
     :out-path "public"}))
@@ -45,7 +45,7 @@
   ([_]
    (swap! config/!resource->url merge {"/js/viewer.js" "/js/main.js"})
    (clerk/build!
-    {:paths ["dev/mathlive/notebook.clj"]
+    {:index "dev/mathlive/notebook.clj"
      :bundle? false
      :browse? false
      :out-path "public"})))

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "mathlive.cljs",
       "version": "0.0.1",
       "dependencies": {
-        "mathlive": "0.85.1"
+        "@cortex-js/compute-engine": "^0.12.1",
+        "@mentatcollective/mathlive": "0.85.2"
       },
       "devDependencies": {
         "@babel/core": "^7.17.9",
@@ -392,6 +393,19 @@
         "w3c-keyname": "^2.2.4"
       }
     },
+    "node_modules/@cortex-js/compute-engine": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.12.1.tgz",
+      "integrity": "sha512-oOb8Wn0vbI1agJt/vW/4AnIOvyUYifpQItF7YB9bsQCgJ6iqzfYGTTb79gBns0BVzJL/GWap/fByNjMNP4soBQ==",
+      "dependencies": {
+        "complex.js": "^2.1.1",
+        "decimal.js": "^10.4.0"
+      },
+      "engines": {
+        "node": ">=16.14.2",
+        "npm": ">=8.5.0"
+      }
+    },
     "node_modules/@emotion/is-prop-valid": {
       "version": "0.8.8",
       "dev": true,
@@ -460,6 +474,19 @@
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@mentatcollective/mathlive": {
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@mentatcollective/mathlive/-/mathlive-0.85.2.tgz",
+      "integrity": "sha512-gHPAunh+9P6n/jfqtZATQvRrkLq2Fd5UnEXcMqQzDTZNZ0NN8ZFJX1VFsQagKyNNWXxwcR1O40Kb1ekePiQ42A==",
+      "engines": {
+        "node": ">=16.14.2",
+        "npm": ">=8.5.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paypal.me/arnogourdol"
       }
     },
     "node_modules/@motionone/animation": {
@@ -1246,6 +1273,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/complex.js": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.1.1.tgz",
+      "integrity": "sha512-8njCHOTtFFLtegk6zQo0kkVX1rngygb/KQI6z1qZxlFI3scluC+LVTCFbrkWjBv4vvLlbQ9t88IPMC6k95VTTg==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/infusion"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "dev": true,
@@ -1394,6 +1433,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.2.tgz",
+      "integrity": "sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA=="
     },
     "node_modules/des.js": {
       "version": "1.0.1",
@@ -2399,19 +2443,6 @@
         "mathbox": "^2.1.4",
         "react": "^17.0.2 || ^18.0.0",
         "three": ">=0.118.0"
-      }
-    },
-    "node_modules/mathlive": {
-      "version": "0.85.1",
-      "resolved": "https://registry.npmjs.org/mathlive/-/mathlive-0.85.1.tgz",
-      "integrity": "sha512-L5s5MJbpm407awCGYLE6NhToyDhRHyAT0KzNHzvYKL06kdpcMUQaMKKPIBRnhC+iHpIod/QtaqXr2R8qQrNg0Q==",
-      "engines": {
-        "node": ">=16.14.2",
-        "npm": ">=8.5.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paypal.me/arnogourdol"
       }
     },
     "node_modules/md5.js": {
@@ -3898,6 +3929,15 @@
         "w3c-keyname": "^2.2.4"
       }
     },
+    "@cortex-js/compute-engine": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.12.1.tgz",
+      "integrity": "sha512-oOb8Wn0vbI1agJt/vW/4AnIOvyUYifpQItF7YB9bsQCgJ6iqzfYGTTb79gBns0BVzJL/GWap/fByNjMNP4soBQ==",
+      "requires": {
+        "complex.js": "^2.1.1",
+        "decimal.js": "^10.4.0"
+      }
+    },
     "@emotion/is-prop-valid": {
       "version": "0.8.8",
       "dev": true,
@@ -3952,6 +3992,11 @@
       "requires": {
         "@lezer/common": "^1.0.0"
       }
+    },
+    "@mentatcollective/mathlive": {
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@mentatcollective/mathlive/-/mathlive-0.85.2.tgz",
+      "integrity": "sha512-gHPAunh+9P6n/jfqtZATQvRrkLq2Fd5UnEXcMqQzDTZNZ0NN8ZFJX1VFsQagKyNNWXxwcR1O40Kb1ekePiQ42A=="
     },
     "@motionone/animation": {
       "version": "10.14.0",
@@ -4543,6 +4588,11 @@
       "version": "1.0.1",
       "dev": true
     },
+    "complex.js": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.1.1.tgz",
+      "integrity": "sha512-8njCHOTtFFLtegk6zQo0kkVX1rngygb/KQI6z1qZxlFI3scluC+LVTCFbrkWjBv4vvLlbQ9t88IPMC6k95VTTg=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "dev": true
@@ -4655,6 +4705,11 @@
       "requires": {
         "ms": "2.1.2"
       }
+    },
+    "decimal.js": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.2.tgz",
+      "integrity": "sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA=="
     },
     "des.js": {
       "version": "1.0.1",
@@ -5313,11 +5368,6 @@
       "requires": {
         "lodash": "^4.17.21"
       }
-    },
-    "mathlive": {
-      "version": "0.85.1",
-      "resolved": "https://registry.npmjs.org/mathlive/-/mathlive-0.85.1.tgz",
-      "integrity": "sha512-L5s5MJbpm407awCGYLE6NhToyDhRHyAT0KzNHzvYKL06kdpcMUQaMKKPIBRnhC+iHpIod/QtaqXr2R8qQrNg0Q=="
     },
     "md5.js": {
       "version": "1.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mathlive.cljs",
       "version": "0.0.1",
       "dependencies": {
-        "@mentatcollective/mathlive": "^0.85.0"
+        "mathlive": "0.85.1"
       },
       "devDependencies": {
         "@babel/core": "^7.17.9",
@@ -460,19 +460,6 @@
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
-      }
-    },
-    "node_modules/@mentatcollective/mathlive": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@mentatcollective/mathlive/-/mathlive-0.85.0.tgz",
-      "integrity": "sha512-e7++DoWtjkWZbNzOJY/ZJXITgWRd/HONQlbrIqdySpKLuDaP90FvO1ueCjADMNYweOk2AY3b4EJAiayzHirazw==",
-      "engines": {
-        "node": ">=16.14.2",
-        "npm": ">=8.5.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paypal.me/arnogourdol"
       }
     },
     "node_modules/@motionone/animation": {
@@ -2414,6 +2401,19 @@
         "three": ">=0.118.0"
       }
     },
+    "node_modules/mathlive": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/mathlive/-/mathlive-0.85.1.tgz",
+      "integrity": "sha512-L5s5MJbpm407awCGYLE6NhToyDhRHyAT0KzNHzvYKL06kdpcMUQaMKKPIBRnhC+iHpIod/QtaqXr2R8qQrNg0Q==",
+      "engines": {
+        "node": ">=16.14.2",
+        "npm": ">=8.5.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paypal.me/arnogourdol"
+      }
+    },
     "node_modules/md5.js": {
       "version": "1.3.5",
       "dev": true,
@@ -3953,11 +3953,6 @@
         "@lezer/common": "^1.0.0"
       }
     },
-    "@mentatcollective/mathlive": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@mentatcollective/mathlive/-/mathlive-0.85.0.tgz",
-      "integrity": "sha512-e7++DoWtjkWZbNzOJY/ZJXITgWRd/HONQlbrIqdySpKLuDaP90FvO1ueCjADMNYweOk2AY3b4EJAiayzHirazw=="
-    },
     "@motionone/animation": {
       "version": "10.14.0",
       "dev": true,
@@ -5318,6 +5313,11 @@
       "requires": {
         "lodash": "^4.17.21"
       }
+    },
+    "mathlive": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/mathlive/-/mathlive-0.85.1.tgz",
+      "integrity": "sha512-L5s5MJbpm407awCGYLE6NhToyDhRHyAT0KzNHzvYKL06kdpcMUQaMKKPIBRnhC+iHpIod/QtaqXr2R8qQrNg0Q=="
     },
     "md5.js": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mathlive.cljs",
   "version": "0.0.1",
   "dependencies": {
-    "@mentatcollective/mathlive": "^0.85.0"
+    "mathlive": "0.85.1"
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "mathlive.cljs",
   "version": "0.0.1",
   "dependencies": {
-    "mathlive": "0.85.1"
+    "@cortex-js/compute-engine": "^0.12.1",
+    "@mentatcollective/mathlive": "0.85.2"
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",
@@ -39,7 +40,8 @@
   },
   "homepage": "https://mentat-collective.github.io/mathlive.cljs",
   "scripts": {
-    "serve": "http-server -c-1",
+    "serve": "http-server -c-1 -o",
+    "gh-pages": "gh-pages -d public",
     "watch-clerk": "shadow-cljs watch clerk",
     "release-clerk": "shadow-cljs release clerk"
   }

--- a/src/deps.cljs
+++ b/src/deps.cljs
@@ -1,2 +1,3 @@
 {:npm-deps
- {"@mentatcollective/mathlive" "^0.85.0"}}
+ {"@cortex-js/compute-engine" "^0.12.1",
+  "@mentatcollective/mathlive" "0.85.2"}}

--- a/src/mathlive/core.cljs
+++ b/src/mathlive/core.cljs
@@ -4,7 +4,7 @@
   associated utilities."
   (:require [goog.object :as obj]
             [reagent.core :as r]
-            ["@mentatcollective/mathlive" :as mathl]
+            ["mathlive" :as mathl]
             ["react" :as react]))
 
 ;; ## Utilities

--- a/src/mathlive/core.cljs
+++ b/src/mathlive/core.cljs
@@ -5,7 +5,7 @@
   (:require [goog.object :as obj]
             [reagent.core :as r]
             ["@cortex-js/compute-engine" :refer [ComputeEngine]]
-            ["@mentatcollective/mathlive/dist/mathlive.js" :as ml]
+            ["@mentatcollective/mathlive/dist/mathlive.js" #_#_ :as ml]
             ["react" :as react]))
 
 ;; ## Utilities
@@ -42,7 +42,7 @@
 (def ^{:doc "Currently loaded version of
 the [mathlive](https://www.npmjs.com/package/mathlive) npm package. "}
   mathlive-version
-  "0.84.0"
+  "0.85.1"
   ;; TODO enable this again once we get back to mainline mathlive vs our fork.
   #_(.-mathlive ml/version))
 
@@ -81,11 +81,11 @@ the [mathlive](https://www.npmjs.com/package/mathlive) npm package. "}
                      v (if (= type "math-json")
                          (->math-json field)
                          (.getValue field type))]
-                 (assoc acc k v)))
+                 (assoc acc (keyword k) v)))
              {}
              (js-keys m)))))
 
-(def engine
+(def ^:no-doc engine
   (ComputeEngine.))
 
 (defn math-json->tex
@@ -201,9 +201,3 @@ the [mathlive](https://www.npmjs.com/package/mathlive) npm package. "}
                  "onInput" onChange
                  "sounds-directory" (or soundsDirectory cdn-sounds)
                  "fonts-directory" (or fontsDirectory cdn-fonts))]))))))
-
-
-(r/with-let [!tex (r/atom "")]
-  [:div
-   [ml/MathField {:value @!tex}]
-   [:pre @!tex]])


### PR DESCRIPTION
This PR:

- upgrades Mathlive to the latest version, still deployed by Mentat but ready to be replaced soon!
- beefs up the docs notebook
- adds a good README

Gunning toward a real release.