### PR TITLE
Remove goog.object references, support SCI evaluation

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -2,4 +2,4 @@
   . ((cider-default-cljs-repl . node)))
  (clojure-mode
   . ((cider-preferred-build-tool . clojure-cli)
-     (cider-clojure-cli-aliases . ":dev:clerk"))))
+     (cider-clojure-cli-aliases . ":nextjournal/clerk"))))

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,29 +10,28 @@ jobs:
     steps:
       - uses: actions/cache@v3
         with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/deps.edn') }}
-          restore-keys: ${{ runner.os }}-m2
+            path: |
+              .cpcache
+              .shadow-cljs
+              ~/.m2
+            key: "1"
 
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@4.0
+        uses: DeLaGuardo/setup-clojure@master
         with:
           cli: latest
+          bb: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install babashka
-        uses: just-sultanov/setup-babashka@v2
-        with:
-          version: '0.8.156'
 
       - name: Build static site
         run: bb build-static
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public/build

--- a/.github/workflows/kondo.yml
+++ b/.github/workflows/kondo.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install babashka
-        uses: just-sultanov/setup-babashka@v2
+      - name: Install Babashka
+        uses: DeLaGuardo/setup-clojure@10.2
         with:
-          version: '0.8.156'
+          bb: latest
 
       - name: Cache kondo directory
         uses: actions/cache@v2
@@ -24,5 +24,8 @@ jobs:
           key: ${{ runner.os }}-kondo
           restore-keys: ${{ runner.os }}-kondo
 
-      - name: Run clj-kondo
+      - name: Lint dependencies
+        run: bb lint-deps
+
+      - name: Lint project files
         run: bb lint --config '{:output {:pattern "::{{level}} file={{filename}},line={{row}},col={{col}}::{{message}}"}}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [unreleased]
 
+## [0.2.1]
+
+- #15:
+
+  - removes the `goog.object` to make the library compatible with SCI
+    evaluation, needed by Portal.
+
+  - adds various build upgrades, (Clerk, Kondo etc)
+
 ## [0.2.0]
 
 The interactive docs page is now published to https://mathlive.mentat.org.

--- a/bb.edn
+++ b/bb.edn
@@ -1,9 +1,9 @@
 {:deps {org.babashka/http-server {:mvn/version "0.1.11"}
-        org.babashka/cli {:mvn/version "0.2.23"}}
- :pods {clj-kondo/clj-kondo {:version "2023.01.20"}}
+        org.babashka/cli {:mvn/version "0.2.23"}
+        io.github.clj-kondo/clj-kondo-bb
+        {:git/tag "v2023.01.20" :git/sha "adfc7df"}}
  :tasks
- {:requires ([babashka.cli :as cli]
-             [pod.borkdude.clj-kondo :as clj-kondo])
+ {:requires ([babashka.cli :as cli])
   :init
   (do (def cli-opts
         (cli/parse-opts *command-line-args* {:coerce {:port :int}}))
@@ -51,7 +51,16 @@
   {:doc "Release the library to Clojars."
    :task (shell "clojure -T:build publish")}
 
+  lint-deps
+  {:requires ([clj-kondo.core :as kondo])
+   :doc "Lint dependencies."
+   :task (kondo/run!
+          {:lint [(with-out-str
+                    (babashka.tasks/clojure
+                     "-Spath -A:nextjournal/clerk"))]
+           :dependencies true})}
+
   lint
   {:doc "Lint the src and dev directories with clj-kondo."
-   :task (clj-kondo/print!
-          (clj-kondo/run! {:lint ["src" "dev"]}))}}}
+   :task (exec 'clj-kondo.core/exec)
+   :exec-args {:lint ["src" "dev"]}}}}

--- a/build.clj
+++ b/build.clj
@@ -17,7 +17,7 @@
 ;; ## Variables
 
 (def lib 'org.mentat/mathlive.cljs)
-(def version "0.2.0")
+(def version "0.2.1")
 (def pom-deps
   {'org.babashka/sci
    {:mvn/version "0.6.37"

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {reagent/reagent {:mvn/version "1.1.1"}}
+ :deps {reagent/reagent {:mvn/version "1.2.0"}}
 
  :aliases
  {:nextjournal/clerk
@@ -7,17 +7,17 @@
    :extra-deps
    {org.clojure/clojure       {:mvn/version "1.11.1"}
     org.clojure/clojurescript {:mvn/version "1.11.60"}
-    org.mentat/clerk-utils    {:mvn/version "0.4.1"}
+    org.mentat/clerk-utils    {:mvn/version "0.6.0"}
 
     io.github.nextjournal/clerk
-    {:git/sha "fad499407d979916d21b33cc7e46e73f7a485e37"}
+    {:git/sha "1f6c5331418aaf9c5a4335fc2e6e95f07dc3af6b"}
     io.github.nextjournal/clerk.render
     {:git/url "https://github.com/nextjournal/clerk"
-     :git/sha "fad499407d979916d21b33cc7e46e73f7a485e37"
+     :git/sha "1f6c5331418aaf9c5a4335fc2e6e95f07dc3af6b"
      :deps/root "render"}}
    :exec-fn user/build!}
 
   :build
-  {:deps {io.github.clojure/tools.build {:git/tag "v0.8.2" :git/sha "ba1a2bf"}
+  {:deps {io.github.clojure/tools.build {:git/tag "v0.9.4" :git/sha "76b78fe"}
           slipset/deps-deploy {:mvn/version "0.2.0"}}
    :ns-default build}}}

--- a/dev/mathlive/notebook.clj
+++ b/dev/mathlive/notebook.clj
@@ -1,17 +1,17 @@
-^#:nextjournal.clerk
-{:toc true
- :no-cache true
- :visibility :hide-ns}
+^{:nextjournal.clerk/visibility {:code :hide}}
 (ns mathlive.notebook
+  #:nextjournal.clerk{:toc true :no-cache true}
   (:require [mentat.clerk-utils.docs :as docs]
             [mentat.clerk-utils.show :refer [show-sci]]
             [nextjournal.clerk :as clerk]))
 
+{::clerk/width :wide}
+
 ^{::clerk/visibility {:code :hide :result :hide}}
 (clerk/eval-cljs
  ;; These aliases only apply inside this namespace.
- '(require '[mathlive.core :as ml])
- '(require '[reagent.core :as reagent]))
+ '(do (require '[mathlive.core :as ml])
+      (require '[reagent.core :as reagent])))
 
 ;; # MathLive.cljs
 ;;
@@ -79,6 +79,7 @@
  ;; These are some styles.
  [:style "
 math-field {
+  width: 100%;
   font-size: 24px;
   border-radius: 4px;
   border: 1px solid;
@@ -324,10 +325,12 @@ math-field:focus-within {
 ;;
 ;; > The appearance and behavior of the mathfield is highly customizable.
 ;;
-;; The `Mathfield` instances in this notebook have all been customized with the following styles:
+;; The `Mathfield` instances in this notebook have all been customized with the
+;; following styles:
 ;;
 ;;```css
 ;; math-field {
+;;   width: 100%;
 ;;   font-size: 24px;
 ;;   border-radius: 4px;
 ;;   border: 1px solid;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,19 +5,19 @@
   "packages": {
     "": {
       "dependencies": {
-        "@codemirror/autocomplete": "6.4.1",
-        "@codemirror/commands": "6.2.1",
+        "@codemirror/autocomplete": "6.7.1",
+        "@codemirror/commands": "6.2.4",
         "@codemirror/lang-markdown": "6.0.0",
-        "@codemirror/language": "6.6.0",
-        "@codemirror/lint": "6.1.1",
-        "@codemirror/search": "6.2.3",
-        "@codemirror/state": "6.2.0",
-        "@codemirror/view": "6.9.0",
-        "@cortex-js/compute-engine": "0.12.2",
-        "@lezer/common": "1.0.2",
-        "@lezer/generator": "1.2.2",
-        "@lezer/highlight": "1.1.3",
-        "@lezer/lr": "1.3.3",
+        "@codemirror/language": "6.7.0",
+        "@codemirror/lint": "6.2.2",
+        "@codemirror/search": "6.5.0",
+        "@codemirror/state": "6.2.1",
+        "@codemirror/view": "6.13.0",
+        "@cortex-js/compute-engine": "0.12.3",
+        "@lezer/common": "1.0.3",
+        "@lezer/generator": "1.2.3",
+        "@lezer/highlight": "1.1.6",
+        "@lezer/lr": "1.3.6",
         "@lezer/markdown": "1.0.2",
         "@nextjournal/lang-clojure": "1.0.0",
         "@nextjournal/lezer-clojure": "1.0.0",
@@ -33,19 +33,19 @@
         "punycode": "2.1.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "shadow-cljs": "2.20.14",
+        "shadow-cljs": "2.23.1",
         "use-sync-external-store": "1.2.0",
         "vh-sticky-table-header": "1.2.1",
-        "w3c-keyname": "2.2.6"
+        "w3c-keyname": "2.2.8"
       },
       "devDependencies": {
         "gh-pages": "^3.2.3"
       }
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.4.1.tgz",
-      "integrity": "sha512-06yAmj0FjPZzYOpNeugJtG28GNqU2/CPr34m91Q+fKSyTOR6+hDFiatkPcIkxOlU0K5yP7WH6KoLg3fTqIUgaw==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.7.1.tgz",
+      "integrity": "sha512-hSxf9S0uB+GV+gBsjY1FZNo53e1FFdzPceRfCfD1gWOnV6o21GfB5J5Wg9G/4h76XZMPrF0A6OCK/Rz5+V1egg==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.1.tgz",
-      "integrity": "sha512-FFiNKGuHA5O8uC6IJE5apI5rT9gyjlw4whqy4vlcX0wE/myxL6P1s0upwDhY4HtMWLOwzwsp0ap3bjdQhvfDOA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.4.tgz",
+      "integrity": "sha512-42lmDqVH0ttfilLShReLXsDfASKLXzfyC36bzwcqzox9PlHulMcsUOfHXNo2X2aFMVNUoQ7j+d4q5bnfseYoOA==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.2.0",
@@ -71,20 +71,21 @@
       }
     },
     "node_modules/@codemirror/lang-css": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.0.2.tgz",
-      "integrity": "sha512-4V4zmUOl2Glx0GWw0HiO1oGD4zvMlIQ3zx5hXOE6ipCjhohig2bhWRAasrZylH9pRNTcl1VMa59Lsl8lZWlTzw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.2.0.tgz",
+      "integrity": "sha512-oyIdJM29AyRPM3+PPq1I2oIk8NpUfEN3kAM05XWDDs6o3gSneIKaVJifT2P+fqONLou2uIgXynFyMUDQvo/szA==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
         "@lezer/css": "^1.0.0"
       }
     },
     "node_modules/@codemirror/lang-html": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.2.tgz",
-      "integrity": "sha512-bqCBASkteKySwtIbiV/WCtGnn/khLRbbiV5TE+d9S9eQJD7BA4c5dTRm2b3bVmSpilff5EYxvB4PQaZzM/7cNw==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.4.tgz",
+      "integrity": "sha512-NbrqEp0GUOSvhZbG6BxVcS4SzM4SvN5vkkD2sEoETHIyHLZDb9pO1z+r1L2heb6LuF4bUeBCXKjHXoSeDJHO1w==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/lang-css": "^6.0.0",
@@ -98,9 +99,9 @@
       }
     },
     "node_modules/@codemirror/lang-javascript": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.1.4.tgz",
-      "integrity": "sha512-OxLf7OfOZBTMRMi6BO/F72MNGmgOd9B0vetOLvHsDACFXayBzW8fm8aWnDM0yuy68wTK03MBf4HbjSBNRG5q7A==",
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.1.9.tgz",
+      "integrity": "sha512-z3jdkcqOEBT2txn2a87A0jSy6Te3679wg/U8QzMeftFt+4KA6QooMwfdFzJiuC3L6fXKfTXZcDocoaxMYfGz0w==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.6.0",
@@ -125,9 +126,9 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.6.0.tgz",
-      "integrity": "sha512-cwUd6lzt3MfNYOobdjf14ZkLbJcnv4WtndYaoBkbor/vF+rCNguMPK0IRtvZJG4dsWiaWPcK8x1VijhvSxnstg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.7.0.tgz",
+      "integrity": "sha512-4SMwe6Fwn57klCUsVN0y4/h/iWT+XIXFEmop2lIHHuWO0ubjCrF3suqSZLyOQlznxkNnNbOOfKe5HQbQGCAmTg==",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -138,9 +139,9 @@
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.1.1.tgz",
-      "integrity": "sha512-e+M543x0NVHGayNHQzLP4XByJsvbu/ojY6+0VF2Y4Uu66Rt1nADuxNflZwECLf7gS009smIsptSUa6bUj/U/rw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.2.2.tgz",
+      "integrity": "sha512-kHGuynBHjqinp1Bx25D2hgH8a6Fh1m9rSmZFzBVTqPIXDIcZ6j3VI67DY8USGYpGrjrJys9R52eLxtfERGNozg==",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -148,9 +149,9 @@
       }
     },
     "node_modules/@codemirror/search": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.2.3.tgz",
-      "integrity": "sha512-V9n9233lopQhB1dyjsBK2Wc1i+8hcCqxl1wQ46c5HWWLePoe4FluV3TGHoZ04rBRlGjNyz9DTmpJErig8UE4jw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.0.tgz",
+      "integrity": "sha512-64/M40YeJPToKvGO6p3fijo2vwUEj4nACEAXElCaYQ50HrXSvRaK+NHEhSh73WFBGdvIdhrV+lL9PdJy2RfCYA==",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -158,14 +159,14 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.0.tgz",
-      "integrity": "sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.1.tgz",
+      "integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw=="
     },
     "node_modules/@codemirror/view": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.9.0.tgz",
-      "integrity": "sha512-uFaqE6fBOp0Dj/tmWoe/TFlSSIPdpAzhvATgbq1eAKRkgq3hY79FioZ7nfdiT+24kz68AIWuSZ9hi3psKe36WQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.13.0.tgz",
+      "integrity": "sha512-oXTfJzHJ5Tl7f6T8ZO0HKf981zubxgKohjddLobbntbNZHlOZGMRL+pPZGtclDWFaFJWtGBYRGyNdjQ6Xsx5yA==",
       "dependencies": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.0.0",
@@ -173,9 +174,9 @@
       }
     },
     "node_modules/@cortex-js/compute-engine": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.12.2.tgz",
-      "integrity": "sha512-MxXYwCsHzcuzpC81khhp+r0/PN6gO8/Kb9kDeATFUwGqDU0sfejskvmiblQI5xlc323WVSGQOXNemqHFBgCx5g==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.12.3.tgz",
+      "integrity": "sha512-LuiSWMSlgsLFcRWm5ifR8ZeE9HXWOrJ+hE6F211eVI+S+w9SQQvZhhCdUCBusyspW0+29R8lksJPH4qFFr3Xag==",
       "dependencies": {
         "complex.js": "^2.1.1",
         "decimal.js": "^10.4.0"
@@ -201,23 +202,23 @@
       "optional": true
     },
     "node_modules/@lezer/common": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.2.tgz",
-      "integrity": "sha512-SVgiGtMnMnW3ActR8SXgsDhw7a0w0ChHSYAyAUxxrOiJ1OqYWEKk/xJd84tTSPo1mo6DXLObAJALNnd0Hrv7Ng=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.3.tgz",
+      "integrity": "sha512-JH4wAXCgUOcCGNekQPLhVeUtIqjH0yPBs7vvUdSjyQama9618IOKFJwkv2kcqdhF0my8hQEgCTEJU0GIgnahvA=="
     },
     "node_modules/@lezer/css": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.1.tgz",
-      "integrity": "sha512-mSjx+unLLapEqdOYDejnGBokB5+AiJKZVclmud0MKQOKx3DLJ5b5VTCstgDDknR6iIV4gVrN6euzsCnj0A2gQA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.2.tgz",
+      "integrity": "sha512-5TKMAReXukfEmIiZprDlGfZVfOOCyEStFi1YLzxclm9H3G/HHI49/2wzlRT6bQw5r7PoZVEtjTItEkb/UuZQyg==",
       "dependencies": {
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/generator": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@lezer/generator/-/generator-1.2.2.tgz",
-      "integrity": "sha512-O//eH9jTPM1GnbZruuD23xU68Pkuragonn1DEIom4Kt/eJN/QFt7Vzvp1YjV/XBmoUKC+2ySPgrA5fMF9FMM2g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/generator/-/generator-1.2.3.tgz",
+      "integrity": "sha512-xRmNryYbJpWs7novjWtQLCGHOj71B4X1QHQ4SgJqwm11tl6COEVAGhuFTXKX16JMJUhumdXaX8We6hEMd4clDg==",
       "dependencies": {
         "@lezer/common": "^1.0.2",
         "@lezer/lr": "^1.3.0"
@@ -227,17 +228,17 @@
       }
     },
     "node_modules/@lezer/highlight": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.3.tgz",
-      "integrity": "sha512-3vLKLPThO4td43lYRBygmMY18JN3CPh9w+XS2j8WC30vR4yZeFG4z1iFe4jXE43NtGqe//zHW5q8ENLlHvz9gw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.6.tgz",
+      "integrity": "sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@lezer/html": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.2.tgz",
-      "integrity": "sha512-LKGyDdqqDugXR/lKM9FwaKEfMerbZ/aqvhLf0P1FLLK/pVP7wKHXGcg6g3cJ7ckvFidn0tXA8jioG0irVsCBAQ==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.4.tgz",
+      "integrity": "sha512-HdJYMVZcT4YsMo7lW3ipL4NoyS2T67kMPuSVS5TgLGqmaCjEU/D6xv7zsa1ktvTK5lwk7zzF1e3eU6gBZIPm5g==",
       "dependencies": {
         "@lezer/common": "^1.0.0",
         "@lezer/highlight": "^1.0.0",
@@ -245,18 +246,18 @@
       }
     },
     "node_modules/@lezer/javascript": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.1.tgz",
-      "integrity": "sha512-Hqx36DJeYhKtdpc7wBYPR0XF56ZzIp0IkMO/zNNj80xcaFOV4Oj/P7TQc/8k2TxNhzl7tV5tXS8ZOCPbT4L3nA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.3.tgz",
+      "integrity": "sha512-k7Eo9z9B1supZ5cCD4ilQv/RZVN30eUQL+gGbr6ybrEY3avBAL5MDiYi2aa23Aj0A79ry4rJRvPAwE2TM8bd+A==",
       "dependencies": {
         "@lezer/highlight": "^1.1.3",
         "@lezer/lr": "^1.3.0"
       }
     },
     "node_modules/@lezer/lr": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.3.tgz",
-      "integrity": "sha512-JPQe3mwJlzEVqy67iQiiGozhcngbO8QBgpqZM6oL1Wj/dXckrEexpBLeFkq0edtW5IqnPRFxA24BHJni8Js69w==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.6.tgz",
+      "integrity": "sha512-IDhcWjfxwWACnatUi0GzWBCbochfqxo3LZZlS27LbJh8RVYYXXyR5Ck9659IhkWkhSW/kZlaaiJpUO+YZTUK+Q==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -507,9 +508,9 @@
       }
     },
     "node_modules/browserify-sign/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -638,9 +639,9 @@
       }
     },
     "node_modules/crelt": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
-      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
     },
     "node_modules/crypto-browserify": {
       "version": "3.12.0",
@@ -674,9 +675,9 @@
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/des.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
-      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
       "dependencies": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
@@ -1031,9 +1032,9 @@
       }
     },
     "node_modules/hash-base/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -1498,9 +1499,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -1599,13 +1600,13 @@
       }
     },
     "node_modules/shadow-cljs": {
-      "version": "2.20.14",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.14.tgz",
-      "integrity": "sha512-ZwaPLsLoUgYAuuAlKnq1QMArrJzs05AB/yrpdVVLdpK2s7Kr8RX9+0pNfPuCjZDS4vVDCrTmJ5NpU2VoZWZRWQ==",
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.23.1.tgz",
+      "integrity": "sha512-qPI8FyRSmOJgl24svvrWvA/29fA94CVo89X0v6B4eaH/uex5NBSBZqyw58Bo4ZBu0YUxEXnwB8BSHLgmAzf8LQ==",
       "dependencies": {
         "node-libs-browser": "^2.2.1",
         "readline-sync": "^1.4.7",
-        "shadow-cljs-jar": "1.3.2",
+        "shadow-cljs-jar": "1.3.4",
         "source-map-support": "^0.4.15",
         "which": "^1.3.1",
         "ws": "^7.4.6"
@@ -1618,9 +1619,9 @@
       }
     },
     "node_modules/shadow-cljs-jar": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz",
-      "integrity": "sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.4.tgz",
+      "integrity": "sha512-cZB2pzVXBnhpJ6PQdsjO+j/MksR28mv4QD/hP/2y1fsIa9Z9RutYgh3N34FZ8Ktl4puAXaIGlct+gMCJ5BmwmA=="
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -1679,9 +1680,9 @@
       }
     },
     "node_modules/style-mod": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
-      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.3.tgz",
+      "integrity": "sha512-78Jv8kYJdjbvRwwijtCevYADfsI0lGzYJe4mMFdceO8l75DFFDoqBhR1jVDicDRRaX4//g1u9wKeo+ztc2h1Rw=="
     },
     "node_modules/style-value-types": {
       "version": "5.0.0",
@@ -1720,9 +1721,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
     },
     "node_modules/tty-browserify": {
       "version": "0.0.0",
@@ -1785,9 +1786,9 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
     },
     "node_modules/w3c-keyname": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
-      "integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg=="
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "node_modules/which": {
       "version": "1.3.1",
@@ -1836,9 +1837,9 @@
   },
   "dependencies": {
     "@codemirror/autocomplete": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.4.1.tgz",
-      "integrity": "sha512-06yAmj0FjPZzYOpNeugJtG28GNqU2/CPr34m91Q+fKSyTOR6+hDFiatkPcIkxOlU0K5yP7WH6KoLg3fTqIUgaw==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.7.1.tgz",
+      "integrity": "sha512-hSxf9S0uB+GV+gBsjY1FZNo53e1FFdzPceRfCfD1gWOnV6o21GfB5J5Wg9G/4h76XZMPrF0A6OCK/Rz5+V1egg==",
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -1847,9 +1848,9 @@
       }
     },
     "@codemirror/commands": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.1.tgz",
-      "integrity": "sha512-FFiNKGuHA5O8uC6IJE5apI5rT9gyjlw4whqy4vlcX0wE/myxL6P1s0upwDhY4HtMWLOwzwsp0ap3bjdQhvfDOA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.4.tgz",
+      "integrity": "sha512-42lmDqVH0ttfilLShReLXsDfASKLXzfyC36bzwcqzox9PlHulMcsUOfHXNo2X2aFMVNUoQ7j+d4q5bnfseYoOA==",
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.2.0",
@@ -1858,20 +1859,21 @@
       }
     },
     "@codemirror/lang-css": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.0.2.tgz",
-      "integrity": "sha512-4V4zmUOl2Glx0GWw0HiO1oGD4zvMlIQ3zx5hXOE6ipCjhohig2bhWRAasrZylH9pRNTcl1VMa59Lsl8lZWlTzw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.2.0.tgz",
+      "integrity": "sha512-oyIdJM29AyRPM3+PPq1I2oIk8NpUfEN3kAM05XWDDs6o3gSneIKaVJifT2P+fqONLou2uIgXynFyMUDQvo/szA==",
       "requires": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
         "@lezer/css": "^1.0.0"
       }
     },
     "@codemirror/lang-html": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.2.tgz",
-      "integrity": "sha512-bqCBASkteKySwtIbiV/WCtGnn/khLRbbiV5TE+d9S9eQJD7BA4c5dTRm2b3bVmSpilff5EYxvB4PQaZzM/7cNw==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.4.tgz",
+      "integrity": "sha512-NbrqEp0GUOSvhZbG6BxVcS4SzM4SvN5vkkD2sEoETHIyHLZDb9pO1z+r1L2heb6LuF4bUeBCXKjHXoSeDJHO1w==",
       "requires": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/lang-css": "^6.0.0",
@@ -1885,9 +1887,9 @@
       }
     },
     "@codemirror/lang-javascript": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.1.4.tgz",
-      "integrity": "sha512-OxLf7OfOZBTMRMi6BO/F72MNGmgOd9B0vetOLvHsDACFXayBzW8fm8aWnDM0yuy68wTK03MBf4HbjSBNRG5q7A==",
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.1.9.tgz",
+      "integrity": "sha512-z3jdkcqOEBT2txn2a87A0jSy6Te3679wg/U8QzMeftFt+4KA6QooMwfdFzJiuC3L6fXKfTXZcDocoaxMYfGz0w==",
       "requires": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.6.0",
@@ -1912,9 +1914,9 @@
       }
     },
     "@codemirror/language": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.6.0.tgz",
-      "integrity": "sha512-cwUd6lzt3MfNYOobdjf14ZkLbJcnv4WtndYaoBkbor/vF+rCNguMPK0IRtvZJG4dsWiaWPcK8x1VijhvSxnstg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.7.0.tgz",
+      "integrity": "sha512-4SMwe6Fwn57klCUsVN0y4/h/iWT+XIXFEmop2lIHHuWO0ubjCrF3suqSZLyOQlznxkNnNbOOfKe5HQbQGCAmTg==",
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -1925,9 +1927,9 @@
       }
     },
     "@codemirror/lint": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.1.1.tgz",
-      "integrity": "sha512-e+M543x0NVHGayNHQzLP4XByJsvbu/ojY6+0VF2Y4Uu66Rt1nADuxNflZwECLf7gS009smIsptSUa6bUj/U/rw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.2.2.tgz",
+      "integrity": "sha512-kHGuynBHjqinp1Bx25D2hgH8a6Fh1m9rSmZFzBVTqPIXDIcZ6j3VI67DY8USGYpGrjrJys9R52eLxtfERGNozg==",
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -1935,9 +1937,9 @@
       }
     },
     "@codemirror/search": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.2.3.tgz",
-      "integrity": "sha512-V9n9233lopQhB1dyjsBK2Wc1i+8hcCqxl1wQ46c5HWWLePoe4FluV3TGHoZ04rBRlGjNyz9DTmpJErig8UE4jw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.0.tgz",
+      "integrity": "sha512-64/M40YeJPToKvGO6p3fijo2vwUEj4nACEAXElCaYQ50HrXSvRaK+NHEhSh73WFBGdvIdhrV+lL9PdJy2RfCYA==",
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -1945,14 +1947,14 @@
       }
     },
     "@codemirror/state": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.0.tgz",
-      "integrity": "sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.1.tgz",
+      "integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw=="
     },
     "@codemirror/view": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.9.0.tgz",
-      "integrity": "sha512-uFaqE6fBOp0Dj/tmWoe/TFlSSIPdpAzhvATgbq1eAKRkgq3hY79FioZ7nfdiT+24kz68AIWuSZ9hi3psKe36WQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.13.0.tgz",
+      "integrity": "sha512-oXTfJzHJ5Tl7f6T8ZO0HKf981zubxgKohjddLobbntbNZHlOZGMRL+pPZGtclDWFaFJWtGBYRGyNdjQ6Xsx5yA==",
       "requires": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.0.0",
@@ -1960,9 +1962,9 @@
       }
     },
     "@cortex-js/compute-engine": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.12.2.tgz",
-      "integrity": "sha512-MxXYwCsHzcuzpC81khhp+r0/PN6gO8/Kb9kDeATFUwGqDU0sfejskvmiblQI5xlc323WVSGQOXNemqHFBgCx5g==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.12.3.tgz",
+      "integrity": "sha512-LuiSWMSlgsLFcRWm5ifR8ZeE9HXWOrJ+hE6F211eVI+S+w9SQQvZhhCdUCBusyspW0+29R8lksJPH4qFFr3Xag==",
       "requires": {
         "complex.js": "^2.1.1",
         "decimal.js": "^10.4.0"
@@ -1984,40 +1986,40 @@
       "optional": true
     },
     "@lezer/common": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.2.tgz",
-      "integrity": "sha512-SVgiGtMnMnW3ActR8SXgsDhw7a0w0ChHSYAyAUxxrOiJ1OqYWEKk/xJd84tTSPo1mo6DXLObAJALNnd0Hrv7Ng=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.3.tgz",
+      "integrity": "sha512-JH4wAXCgUOcCGNekQPLhVeUtIqjH0yPBs7vvUdSjyQama9618IOKFJwkv2kcqdhF0my8hQEgCTEJU0GIgnahvA=="
     },
     "@lezer/css": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.1.tgz",
-      "integrity": "sha512-mSjx+unLLapEqdOYDejnGBokB5+AiJKZVclmud0MKQOKx3DLJ5b5VTCstgDDknR6iIV4gVrN6euzsCnj0A2gQA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.2.tgz",
+      "integrity": "sha512-5TKMAReXukfEmIiZprDlGfZVfOOCyEStFi1YLzxclm9H3G/HHI49/2wzlRT6bQw5r7PoZVEtjTItEkb/UuZQyg==",
       "requires": {
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0"
       }
     },
     "@lezer/generator": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@lezer/generator/-/generator-1.2.2.tgz",
-      "integrity": "sha512-O//eH9jTPM1GnbZruuD23xU68Pkuragonn1DEIom4Kt/eJN/QFt7Vzvp1YjV/XBmoUKC+2ySPgrA5fMF9FMM2g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/generator/-/generator-1.2.3.tgz",
+      "integrity": "sha512-xRmNryYbJpWs7novjWtQLCGHOj71B4X1QHQ4SgJqwm11tl6COEVAGhuFTXKX16JMJUhumdXaX8We6hEMd4clDg==",
       "requires": {
         "@lezer/common": "^1.0.2",
         "@lezer/lr": "^1.3.0"
       }
     },
     "@lezer/highlight": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.3.tgz",
-      "integrity": "sha512-3vLKLPThO4td43lYRBygmMY18JN3CPh9w+XS2j8WC30vR4yZeFG4z1iFe4jXE43NtGqe//zHW5q8ENLlHvz9gw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.6.tgz",
+      "integrity": "sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==",
       "requires": {
         "@lezer/common": "^1.0.0"
       }
     },
     "@lezer/html": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.2.tgz",
-      "integrity": "sha512-LKGyDdqqDugXR/lKM9FwaKEfMerbZ/aqvhLf0P1FLLK/pVP7wKHXGcg6g3cJ7ckvFidn0tXA8jioG0irVsCBAQ==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.4.tgz",
+      "integrity": "sha512-HdJYMVZcT4YsMo7lW3ipL4NoyS2T67kMPuSVS5TgLGqmaCjEU/D6xv7zsa1ktvTK5lwk7zzF1e3eU6gBZIPm5g==",
       "requires": {
         "@lezer/common": "^1.0.0",
         "@lezer/highlight": "^1.0.0",
@@ -2025,18 +2027,18 @@
       }
     },
     "@lezer/javascript": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.1.tgz",
-      "integrity": "sha512-Hqx36DJeYhKtdpc7wBYPR0XF56ZzIp0IkMO/zNNj80xcaFOV4Oj/P7TQc/8k2TxNhzl7tV5tXS8ZOCPbT4L3nA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.3.tgz",
+      "integrity": "sha512-k7Eo9z9B1supZ5cCD4ilQv/RZVN30eUQL+gGbr6ybrEY3avBAL5MDiYi2aa23Aj0A79ry4rJRvPAwE2TM8bd+A==",
       "requires": {
         "@lezer/highlight": "^1.1.3",
         "@lezer/lr": "^1.3.0"
       }
     },
     "@lezer/lr": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.3.tgz",
-      "integrity": "sha512-JPQe3mwJlzEVqy67iQiiGozhcngbO8QBgpqZM6oL1Wj/dXckrEexpBLeFkq0edtW5IqnPRFxA24BHJni8Js69w==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.6.tgz",
+      "integrity": "sha512-IDhcWjfxwWACnatUi0GzWBCbochfqxo3LZZlS27LbJh8RVYYXXyR5Ck9659IhkWkhSW/kZlaaiJpUO+YZTUK+Q==",
       "requires": {
         "@lezer/common": "^1.0.0"
       }
@@ -2270,9 +2272,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -2393,9 +2395,9 @@
       }
     },
     "crelt": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
-      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -2426,9 +2428,9 @@
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "des.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
-      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
       "requires": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
@@ -2679,9 +2681,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -3063,9 +3065,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3142,22 +3144,22 @@
       }
     },
     "shadow-cljs": {
-      "version": "2.20.14",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.14.tgz",
-      "integrity": "sha512-ZwaPLsLoUgYAuuAlKnq1QMArrJzs05AB/yrpdVVLdpK2s7Kr8RX9+0pNfPuCjZDS4vVDCrTmJ5NpU2VoZWZRWQ==",
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.23.1.tgz",
+      "integrity": "sha512-qPI8FyRSmOJgl24svvrWvA/29fA94CVo89X0v6B4eaH/uex5NBSBZqyw58Bo4ZBu0YUxEXnwB8BSHLgmAzf8LQ==",
       "requires": {
         "node-libs-browser": "^2.2.1",
         "readline-sync": "^1.4.7",
-        "shadow-cljs-jar": "1.3.2",
+        "shadow-cljs-jar": "1.3.4",
         "source-map-support": "^0.4.15",
         "which": "^1.3.1",
         "ws": "^7.4.6"
       }
     },
     "shadow-cljs-jar": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz",
-      "integrity": "sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.4.tgz",
+      "integrity": "sha512-cZB2pzVXBnhpJ6PQdsjO+j/MksR28mv4QD/hP/2y1fsIa9Z9RutYgh3N34FZ8Ktl4puAXaIGlct+gMCJ5BmwmA=="
     },
     "source-map": {
       "version": "0.5.7",
@@ -3209,9 +3211,9 @@
       }
     },
     "style-mod": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
-      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.3.tgz",
+      "integrity": "sha512-78Jv8kYJdjbvRwwijtCevYADfsI0lGzYJe4mMFdceO8l75DFFDoqBhR1jVDicDRRaX4//g1u9wKeo+ztc2h1Rw=="
     },
     "style-value-types": {
       "version": "5.0.0",
@@ -3243,9 +3245,9 @@
       }
     },
     "tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -3310,9 +3312,9 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
     },
     "w3c-keyname": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
-      "integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg=="
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -6,19 +6,19 @@
     "gh-pages": "gh-pages -d public/build --dotfiles true"
   },
   "dependencies": {
-    "@codemirror/autocomplete": "6.4.1",
-    "@codemirror/commands": "6.2.1",
+    "@codemirror/autocomplete": "6.7.1",
+    "@codemirror/commands": "6.2.4",
     "@codemirror/lang-markdown": "6.0.0",
-    "@codemirror/language": "6.6.0",
-    "@codemirror/lint": "6.1.1",
-    "@codemirror/search": "6.2.3",
-    "@codemirror/state": "6.2.0",
-    "@codemirror/view": "6.9.0",
-    "@cortex-js/compute-engine": "0.12.2",
-    "@lezer/common": "1.0.2",
-    "@lezer/generator": "1.2.2",
-    "@lezer/highlight": "1.1.3",
-    "@lezer/lr": "1.3.3",
+    "@codemirror/language": "6.7.0",
+    "@codemirror/lint": "6.2.2",
+    "@codemirror/search": "6.5.0",
+    "@codemirror/state": "6.2.1",
+    "@codemirror/view": "6.13.0",
+    "@cortex-js/compute-engine": "0.12.3",
+    "@lezer/common": "1.0.3",
+    "@lezer/generator": "1.2.3",
+    "@lezer/highlight": "1.1.6",
+    "@lezer/lr": "1.3.6",
     "@lezer/markdown": "1.0.2",
     "@nextjournal/lang-clojure": "1.0.0",
     "@nextjournal/lezer-clojure": "1.0.0",
@@ -34,9 +34,9 @@
     "punycode": "2.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "shadow-cljs": "2.20.14",
+    "shadow-cljs": "2.23.1",
     "use-sync-external-store": "1.2.0",
     "vh-sticky-table-header": "1.2.1",
-    "w3c-keyname": "2.2.6"
+    "w3c-keyname": "2.2.8"
   }
 }

--- a/src/mathlive/core.cljs
+++ b/src/mathlive/core.cljs
@@ -77,7 +77,7 @@ the [mathlive](https://www.npmjs.com/package/mathlive) npm package."}
                (let [field (aget m k)
                      v (if (= type "math-json")
                          (->math-json field)
-                         (.getValue field type))]
+                         (.getPromptValue ^js mf type))]
                  (assoc acc (keyword k) v)))
              {}
              (js-keys m)))))

--- a/src/mathlive/core.cljs
+++ b/src/mathlive/core.cljs
@@ -122,12 +122,12 @@ the [mathlive](https://www.npmjs.com/package/mathlive) npm package."}
 ;;  "1+x"]
 ;; ```
 
-(def ^{:doc "Reagent component around
-  the [MathLive](https://github.com/arnog/mathlive) equation editor.
+(def Mathfield
+  "Reagent component around the [MathLive](https://github.com/arnog/mathlive)
+  equation editor.
 
   NOTE: Following React's convention, `:on-change` binds a listener to to the
- `input` event. See https://reactjs.org/docs/dom-elements.html#onchange"}
-  Mathfield
+  `input` event. See https://reactjs.org/docs/dom-elements.html#onchange"
   (r/adapt-react-class
    (react/forwardRef
     (fn [props ref]

--- a/src/mathlive/core.cljs
+++ b/src/mathlive/core.cljs
@@ -2,8 +2,7 @@
   "Reagent component wrapping the `math-field` web component from
   the [Mathlive](https://cortexjs.io/docs/mathlive) project, along with
   associated utilities."
-  (:require [goog.object :as obj]
-            [reagent.core :as r]
+  (:require [reagent.core :as r]
             ["mathlive" :as ml]
             ["react" :as react]))
 
@@ -75,7 +74,7 @@ the [mathlive](https://www.npmjs.com/package/mathlive) npm package."}
         :or {type "latex"}}]
    (let [m ^js (.-placeholders mf)]
      (reduce (fn [acc k]
-               (let [field (obj/get m k)
+               (let [field (aget m k)
                      v (if (= type "math-json")
                          (->math-json field)
                          (.getValue field type))]


### PR DESCRIPTION
- #15:

  - removes the `goog.object` to make the library compatible with SCI
    evaluation, needed by Portal.

  - adds various build upgrades, (Clerk, Kondo etc)